### PR TITLE
Handle PyInstaller version compatibility in build script

### DIFF
--- a/build_executable.py
+++ b/build_executable.py
@@ -8,7 +8,21 @@ Run this script after installing PyInstaller to produce a distributable EXE::
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
+
+try:
+    from importlib.metadata import PackageNotFoundError, version as _importlib_version
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.8 fallback
+    from pkg_resources import DistributionNotFound as PackageNotFoundError  # type: ignore
+    from pkg_resources import get_distribution  # type: ignore
+
+    def _get_distribution_version(distribution: str) -> str:
+        return get_distribution(distribution).version
+else:
+    def _get_distribution_version(distribution: str) -> str:
+        return _importlib_version(distribution)
+
 
 try:
     import PyInstaller.__main__  # type: ignore
@@ -18,7 +32,16 @@ except ModuleNotFoundError as exc:  # pragma: no cover - convenience guard
     ) from exc
 
 
-def build() -> None:
+def _supports_modern_collection(pyinstaller_version: str) -> bool:
+    """Return ``True`` when the installed PyInstaller supports collection flags."""
+
+    match = re.match(r"(\d+)", pyinstaller_version)
+    if not match:
+        return False
+    return int(match.group(1)) >= 5
+
+
+def build(pyinstaller_version_override: str | None = None) -> None:
     project_root = Path(__file__).parent
     css_file = project_root / "styles.css"
     if not css_file.exists():
@@ -26,25 +49,56 @@ def build() -> None:
 
     add_data_arg = f"{css_file}{os.pathsep}."
 
-    PyInstaller.__main__.run(
-        [
-            "--noconfirm",
-            "--clean",
-            "--onefile",
-            "--noconsole",
-            "--name",
-            "WebRedesignClientScout",
-            "--add-data",
-            add_data_arg,
-            "--collect-metadata",
-            "streamlit",
-            "--collect-data",
-            "streamlit",
-            "--hidden-import",
-            "streamlit.web.bootstrap",
-            str(project_root / "run_app.py"),
-        ]
-    )
+    if pyinstaller_version_override is not None:
+        pyinstaller_version = pyinstaller_version_override
+    else:
+        try:
+            pyinstaller_version = _get_distribution_version("pyinstaller")
+        except PackageNotFoundError as exc:  # pragma: no cover - should not happen after import
+            raise SystemExit(
+                "Unable to determine the installed PyInstaller version. "
+                "Reinstall the package and try again."
+            ) from exc
+
+    use_modern_collection = _supports_modern_collection(pyinstaller_version)
+
+    pyinstaller_args = [
+        "--noconfirm",
+        "--clean",
+        "--onefile",
+        "--noconsole",
+        "--name",
+        "WebRedesignClientScout",
+        "--add-data",
+        add_data_arg,
+        "--hidden-import",
+        "streamlit.web.bootstrap",
+    ]
+
+    if use_modern_collection:
+        pyinstaller_args.extend(
+            [
+                "--copy-metadata",
+                "streamlit",
+                "--collect-data",
+                "streamlit",
+            ]
+        )
+    else:
+        from PyInstaller.utils import hooks as pyinstaller_hooks  # type: ignore
+
+        streamlit_data_files = list(pyinstaller_hooks.collect_data_files("streamlit"))
+
+        copy_metadata = getattr(pyinstaller_hooks, "copy_metadata", None)
+        if callable(copy_metadata):
+            streamlit_data_files.extend(copy_metadata("streamlit"))
+
+        for src, dest in streamlit_data_files:
+            pyinstaller_args.extend(["--add-data", f"{src}{os.pathsep}{dest}"])
+
+    pyinstaller_args.append(str(project_root / "run_app.py"))
+
+    PyInstaller.__main__.run(pyinstaller_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- detect the installed PyInstaller version via importlib.metadata with a pkg_resources fallback
- choose modern collection flags when PyInstaller is new enough and fall back to manual data/metadata collection otherwise
- allow an optional PyInstaller version override to aid testing the legacy behaviour

## Testing
- python build_executable.py
- python -c "import build_executable; build_executable.build('4.10')"


------
https://chatgpt.com/codex/tasks/task_e_68cc3c99f524832bafb6348dfe527281