### PR TITLE
Set bundled server to listen on port 3000

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -83,7 +83,12 @@ def main() -> None:
     if not script_path.exists():
         raise FileNotFoundError(f"Unable to locate Streamlit app at {script_path!s}")
 
-    flag_options = {"server.headless": False, "global.developmentMode": False}
+    flag_options = {
+        "server.headless": False,
+        "global.developmentMode": False,
+        "server.port": 3000,
+        "server.address": "127.0.0.1",
+    }
     bootstrap.run(str(script_path), "", [], flag_options)
 
 


### PR DESCRIPTION
## Summary
- configure the packaged Streamlit bootstrapper to listen on port 3000 and localhost

## Testing
- python -m compileall run_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cc5de16ae0832b8e39d1f3de73e7d9