### PR TITLE
Ensure packaged app loads Streamlit config options

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -76,6 +76,10 @@ def _ensure_streamlit_metadata() -> None:
 
 _ensure_streamlit_metadata()
 from streamlit.web import bootstrap
+from streamlit.web.bootstrap import load_config_options
+
+# Ensure PyInstaller collects ``load_config_options`` when freezing the app.
+assert bootstrap.load_config_options is load_config_options
 
 
 def main() -> None:
@@ -89,6 +93,7 @@ def main() -> None:
         "server.port": 3000,
         "server.address": "127.0.0.1",
     }
+    bootstrap.load_config_options(flag_options)
     bootstrap.run(str(script_path), "", [], flag_options)
 
 


### PR DESCRIPTION
## Summary
- import `streamlit.web.bootstrap.load_config_options` in the executable entry point so PyInstaller bundles the helper
- invoke `bootstrap.load_config_options` with the desired flag overrides before starting Streamlit so the packaged app honors its port and headless settings

## Testing
- python build_executable.py
- ./dist/WebRedesignClientScout & (followed by curl http://127.0.0.1:3000 and terminating the process)


------
https://chatgpt.com/codex/tasks/task_e_68cda3d1bb0c832bb22680a81f9225ad